### PR TITLE
Fixed CardTriggerHandler to properly add stackable custom abilities

### DIFF
--- a/Patches/CardTriggerHandler.cs
+++ b/Patches/CardTriggerHandler.cs
@@ -16,11 +16,9 @@ namespace API.Patches
 				return true;
 			}
 
-			Predicate<Tuple<Ability, AbilityBehaviour>> checkAbilityExists = tuple =>
-				tuple.Item1 == ability || AbilityCanStackAndIsNotPassive(ability);
 			Plugin.Log.LogDebug($"Attempting to add regular ability in card trigger handler [{ability}]");
 			// return true if the ability is equal to the ability in the pair OR if ability cannot stack and is passive
-			if (!__instance.triggeredAbilities.Exists(checkAbilityExists))
+			if (!__instance.triggeredAbilities.Exists(tuple => tuple.Item1 == ability) || AbilityCanStackAndIsNotPassive(ability))
 			{
 				Plugin.Log.LogDebug($"-> Ability [{ability}] does not exist, adding...");
 				NewAbility newAbility = NewAbility.abilities.Find(x => x.ability == ability);


### PR DESCRIPTION
This PR fixes a defect in the patch for CardTriggerHandler.AddAbility.

Right now, duplicate stackable NewAbilities are not being added to the trigger list because the predicate is always true for stackable abilities. A stackable ability can only be added if the trigger list is empty.

This changes the if statement so that stackable abilities are properly added to the card.