### PR TITLE
Encounter compatibility

### DIFF
--- a/InscryptionAPI/Ascension/AscensionChallengePaginator.cs
+++ b/InscryptionAPI/Ascension/AscensionChallengePaginator.cs
@@ -13,6 +13,10 @@ public class AscensionChallengePaginator : MonoBehaviour
 
     public List<AscensionIconInteractable> bottomRow;
 
+    public AscensionIconInteractable extraIcon;
+
+    public bool showExtraIcon;
+
     public List<List<AscensionChallenge>> pages = new();
 
     private void PageBuilder(List<AscensionChallenge> challenges, int startIdx)
@@ -94,6 +98,11 @@ public class AscensionChallengePaginator : MonoBehaviour
             targetIcon.activatedRenderer.enabled = numActive > target;
             targetIcon.gameObject.SetActive(true);
         }
+
+        if (challengePageIndex == 0 && showExtraIcon)
+            this.extraIcon.gameObject.SetActive(true);
+        else
+            this.extraIcon.gameObject.SetActive(false);
     }
 
     public void ChallengePageLeft(MainInputInteractable button)

--- a/InscryptionAPI/Ascension/AscensionChallengeScreen.cs
+++ b/InscryptionAPI/Ascension/AscensionChallengeScreen.cs
@@ -54,10 +54,13 @@ public static class AscensionChallengeScreenPatches
             paginator.topRow.Add(topRow.transform.Find($"Icon_{i}").gameObject.GetComponent<AscensionIconInteractable>());
             paginator.bottomRow.Add(bottomRow.transform.Find($"Icon_{i+7}").gameObject.GetComponent<AscensionIconInteractable>());
         }
+        paginator.extraIcon = bottomRow.transform.Find($"Icon_15").gameObject.GetComponent<AscensionIconInteractable>();
+        paginator.showExtraIcon = paginator.extraIcon.gameObject.activeSelf;
+
 
         paginator.GeneratePages();
 
-        var pageTuple = AscensionRunSetupScreenBase.BuildPaginators(challengeIconGrid.transform);
+        var pageTuple = AscensionRunSetupScreenBase.BuildPaginators(challengeIconGrid.transform, upperPosition:true);
 
         AscensionMenuInteractable leftController = pageTuple.Item1;
         AscensionMenuInteractable rightController = pageTuple.Item2;

--- a/InscryptionAPI/Ascension/AscensionRunSetupScreenBase.cs
+++ b/InscryptionAPI/Ascension/AscensionRunSetupScreenBase.cs
@@ -65,28 +65,8 @@ public abstract class AscensionRunSetupScreenBase : ManagedBehaviour
             GameObject.Destroy(obj);
     }
 
-    public static (AscensionMenuInteractable, AscensionMenuInteractable) BuildPaginators(Transform parent)
+    public static (AscensionMenuInteractable, AscensionMenuInteractable) BuildPaginators(Transform parent, bool upperPosition = false)
     {
-        // Find the leftmost and rightmost x values
-        // We'll put the arrows halfway between the edge of the screen and the leftmost/rightmost objects
-        float leftX = 1f;
-        float rightX = 0f;
-
-        foreach (Renderer renderer in parent.gameObject.GetComponentsInChildren<Renderer>())
-        {
-            Vector3 min = Camera.main.WorldToViewportPoint(renderer.bounds.min);
-            Vector3 max = Camera.main.WorldToViewportPoint(renderer.bounds.max);
-
-            if (min.x < leftX)
-                leftX = min.x;
-
-            if (max.x > rightX)
-                rightX = max.x;
-        }
-
-        leftX = leftX / 2f;
-        rightX = 1f - ((1f - rightX) / 2f);
-
         GameObject leftPseudoPrefab = AscensionMenuScreens.Instance.cardUnlockSummaryScreen.transform.Find("Unlocks/ScreenAnchor/PageLeftButton").gameObject;
         GameObject rightPseudoPrefab = AscensionMenuScreens.Instance.cardUnlockSummaryScreen.transform.Find("Unlocks/ScreenAnchor/PageRightButton").gameObject;
 
@@ -102,8 +82,37 @@ public abstract class AscensionRunSetupScreenBase : ManagedBehaviour
         leftPos.viewportCam = Camera.main;
         rightPos.viewportCam = Camera.main;
 
-        leftPos.viewportAnchor = new Vector2(leftX, 0.565f);
-        rightPos.viewportAnchor = new Vector2(rightX, 0.565f);
+        if (!upperPosition)
+        {
+
+            // Find the leftmost and rightmost x values
+            // We'll put the arrows halfway between the edge of the screen and the leftmost/rightmost objects
+            float leftX = 1f;
+            float rightX = 0f;
+
+            foreach (Renderer renderer in parent.gameObject.GetComponentsInChildren<Renderer>())
+            {
+                Vector3 min = Camera.main.WorldToViewportPoint(renderer.bounds.min);
+                Vector3 max = Camera.main.WorldToViewportPoint(renderer.bounds.max);
+
+                if (min.x < leftX)
+                    leftX = min.x;
+
+                if (max.x > rightX)
+                    rightX = max.x;
+            }
+
+            leftX = leftX / 2f;
+            rightX = 1f - ((1f - rightX) / 2f);
+
+            leftPos.viewportAnchor = new Vector2(leftX, 0.565f);
+            rightPos.viewportAnchor = new Vector2(rightX, 0.565f);
+        }
+        else
+        {
+            leftPos.viewportAnchor = new Vector2(0.25f, 0.8f);
+            rightPos.viewportAnchor = new Vector2(0.75f, 0.8f);
+        }
 
         leftPos.offset = new (0f, 0f);
         rightPos.offset = new (0f, 0f);

--- a/InscryptionAPI/Ascension/ChallengeManager.cs
+++ b/InscryptionAPI/Ascension/ChallengeManager.cs
@@ -46,6 +46,10 @@ public static class ChallengeManager
                 retval.Add(infos.First(i => i.challengeType == icon2));
         }
 
+        // Can't forget the 15th challenge
+        AscensionChallenge iconFinal = bottomRow.transform.Find($"Icon_15").gameObject.GetComponent<AscensionIconInteractable>().Info.challengeType;
+        retval.Add(infos.First(i => i.challengeType == iconFinal));
+
         return retval;
     }
 

--- a/InscryptionAPI/Ascension/StarterDeckManager.cs
+++ b/InscryptionAPI/Ascension/StarterDeckManager.cs
@@ -64,7 +64,7 @@ public static class StarterDeckManager
         var decks = BaseGameDecks.Concat(NewDecks).Select(x => CloneStarterDeck(x)).ToList();       
 
         foreach (var deck in decks)
-            deck.Info.cards = deck.CardNames.Select(n => CardManager.AllCardsCopy.CardByName(n)).ToList();
+            deck.Info.cards = deck.CardNames.Select(n => CardLoader.GetCardByName(n)).ToList();
 
         AllDecks = ModifyDeckList?.Invoke(decks) ?? decks;
         AllDeckInfos = AllDecks.Select(fsd => fsd.Info).ToList();

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -13,7 +13,20 @@ public static class CardExtensions
     /// <param name="cards">An enumeration of Inscryption cards</param>
     /// <param name="name">The name to search for (case sensitive).</param>
     /// <returns>The first matching card, or null if no match</returns>
-    public static CardInfo CardByName(this IEnumerable<CardInfo> cards, string name) => cards.FirstOrDefault(x => x.name == name);
+    public static CardInfo CardByName(this IEnumerable<CardInfo> cards, string name)
+    {
+        CardInfo retVal = null;
+        foreach (var card in cards)
+        {
+            var cardName = card.name;
+
+            if (cardName.Equals(name, StringComparison.OrdinalIgnoreCase))
+                return card;
+            else if (retVal is null && cardName.EndsWith("_" + name))
+                retVal = card;
+        }
+        return retVal;
+    }
 
     private static Sprite GetPortrait(Texture2D portrait, TextureHelper.SpriteType spriteType, FilterMode? filterMode)
     {

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -204,22 +204,6 @@ public static class CardManager
         ExtensionProperties.Add((CardInfo)__result, ExtensionProperties.GetOrCreateValue(__instance));
     }
 
-    [HarmonyPatch(typeof(AscensionMenuScreens), nameof(AscensionMenuScreens.TransitionToGame))]
-    [HarmonyPrefix]
-    private static void SyncCardsAndAbilitiesWhenTransitioningToAscensionGame()
-    {
-        CardManager.SyncCardList();
-        AbilityManager.SyncAbilityList();
-    }
-
-    [HarmonyPatch(typeof(MenuController), nameof(MenuController.TransitionToGame))]
-    [HarmonyPrefix]
-    private static void SyncCardsAndAbilitiesWhenTransitioningToGame()
-    {
-        CardManager.SyncCardList();
-        AbilityManager.SyncAbilityList();
-    }
-
     [HarmonyPatch(typeof(CardLoader), nameof(CardLoader.GetCardByName))]
     [HarmonyPrefix]
     private static bool GetNonGuidName(string name, out CardInfo __result)

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -24,6 +24,7 @@ public static class CardManager
     public static readonly ReadOnlyCollection<CardInfo> BaseGameCards = new(GetBaseGameCards().ToList());
     private static readonly ObservableCollection<CardInfo> NewCards = new();
     
+    private static bool EventActive = false;
     public static event Func<List<CardInfo>, List<CardInfo>> ModifyCardList;
 
     private static IEnumerable<CardInfo> GetBaseGameCards()
@@ -35,10 +36,15 @@ public static class CardManager
         }
     }
 
+    internal static void ActivateEvents()
+    {
+        EventActive = true;
+    }
+
     public static void SyncCardList()
     {
         var cards = BaseGameCards.Concat(NewCards).Select(x => CardLoader.Clone(x)).ToList();
-        AllCardsCopy = ModifyCardList?.Invoke(cards) ?? cards;
+        AllCardsCopy = EventActive ? ModifyCardList?.Invoke(cards) ?? cards : cards;
     }
 
     private static string GetCardPrefixFromName(this CardInfo info)

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -214,21 +214,7 @@ public static class CardManager
     [HarmonyPrefix]
     private static bool GetNonGuidName(string name, out CardInfo __result)
     {
-        CardInfo retVal = null;
-        foreach (var card in AllCardsCopy)
-        {
-            var cardName = card.name;
-            if (cardName == name)
-            {
-                retVal = card;
-                break;
-            }
-            else if (retVal is null && cardName.EndsWith("_" + name))
-            {
-                retVal = card;
-            }
-        }
-
+        CardInfo retVal = AllCardsCopy.CardByName(name);
         __result = CardLoader.Clone(retVal);
         return false;
     }

--- a/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
+++ b/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
@@ -1,0 +1,126 @@
+using System.Runtime.CompilerServices;
+using DiskCardGame;
+using HarmonyLib;
+
+namespace InscryptionAPI.Card;
+
+[HarmonyPatch]
+public abstract class ExtendedAbilityBehaviour : AbilityBehaviour
+{
+    // This section handles attack slot management
+
+    public virtual bool RespondsToGetOpposingSlots() => false;
+
+    public virtual List<CardSlot> GetOpposingSlots(List<CardSlot> originalSlots, List<CardSlot> otherAddedSlots) => new();
+
+    public virtual bool RemoveDefaultAttackSlot() => false;
+
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetOpposingSlots))]
+    [HarmonyPostfix]
+    private static void UpdateOpposingSlots(ref PlayableCard __instance, ref List<CardSlot> __result)
+    {
+        bool isAttackingDefaultSlot = !__instance.HasTriStrike() && !__instance.HasAbility(Ability.SplitStrike);
+        CardSlot defaultslot = __instance.Slot.opposingSlot;
+
+        List<CardSlot> alteredOpposings = new List<CardSlot>();
+        bool removeDefaultAttackSlot = false;
+
+        List<ExtendedAbilityBehaviour> behaviours = __instance.GetComponents<ExtendedAbilityBehaviour>().Where(x => x.RespondsToGetOpposingSlots()).ToList();            
+        foreach (ExtendedAbilityBehaviour component in behaviours)
+        {
+            alteredOpposings.AddRange(component.GetOpposingSlots(__result, new(alteredOpposings)));
+            removeDefaultAttackSlot = removeDefaultAttackSlot || component.RemoveDefaultAttackSlot();  
+        }
+        
+        if (alteredOpposings.Count > 0) 
+            __result.AddRange(alteredOpposings);
+
+        if (isAttackingDefaultSlot && removeDefaultAttackSlot)
+            __result.Remove(defaultslot);
+    }
+
+    // This section handles passive attack/health buffs
+
+    private static ConditionalWeakTable<PlayableCard, List<ExtendedAbilityBehaviour>> AttackBuffAbilities = new();
+    private static ConditionalWeakTable<PlayableCard, List<ExtendedAbilityBehaviour>> HealthBuffAbilities = new();
+
+    private static List<ExtendedAbilityBehaviour> GetAttackBuffs(PlayableCard card)
+    {
+        List<ExtendedAbilityBehaviour> retval;
+        if (AttackBuffAbilities.TryGetValue(card, out retval))
+            return retval;
+
+        retval = card.GetComponents<ExtendedAbilityBehaviour>().Where(x => x.ProvidesPassiveAttackBuff).ToList();
+        AttackBuffAbilities.Add(card, retval);
+        return retval;
+    }
+
+    private static List<ExtendedAbilityBehaviour> GetHealthBuffs(PlayableCard card)
+    {
+        List<ExtendedAbilityBehaviour> retval;
+        if (HealthBuffAbilities.TryGetValue(card, out retval))
+            return retval;
+
+        retval = card.GetComponents<ExtendedAbilityBehaviour>().Where(x => x.ProvidesPassiveHealthBuff).ToList();
+        HealthBuffAbilities.Add(card, retval);
+        return retval;
+    }
+
+    public virtual bool ProvidesPassiveAttackBuff => false;
+    public virtual bool ProvidesPassiveHealthBuff => false;
+
+    public virtual int[] GetPassiveAttackBuffs() => null;
+    public virtual int[] GetPassiveHealthBuffs() => null;
+
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveAttackBuffs))]
+    [HarmonyPostfix]
+    private static void AddPassiveAttackBuffs(ref PlayableCard __instance, ref int __result)
+    {
+        if (__instance.slot == null)
+            return;
+
+        List<CardSlot> slots = __instance.OpponentCard ? BoardManager.Instance.opponentSlots : BoardManager.Instance.playerSlots;
+
+        foreach (CardSlot slot in slots.Where(s => s.Card != null))
+        {
+            foreach (var b in GetAttackBuffs(slot.Card).Where(ab => ab != null))
+            {
+                int[] buffs = b.GetPassiveAttackBuffs();
+                if (buffs == null)
+                    continue;
+
+                for (int i = 0; i < buffs.Length; i++)
+                {
+                    if (__instance.slot.Index == i)
+                        __result += buffs[i];
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveHealthBuffs))]
+    [HarmonyPostfix]
+    private static void AddPassiveHealthBuffs(ref PlayableCard __instance, ref int __result)
+    {
+        if (__instance.slot == null)
+            return;
+
+        List<CardSlot> slots = __instance.OpponentCard ? BoardManager.Instance.opponentSlots : BoardManager.Instance.playerSlots;
+
+        foreach (CardSlot slot in slots.Where(s => s.Card != null))
+        {
+            foreach (ExtendedAbilityBehaviour b in GetHealthBuffs(slot.Card))
+            {
+                int[] buffs = b.GetPassiveHealthBuffs();
+                if (buffs == null)
+                    continue;
+
+                for (int i = 0; i < buffs.Length; i++)
+                {
+                    if (__instance.slot.Index == i)
+                        __result += buffs[i];
+                }
+            }
+        }
+    }
+}

--- a/InscryptionAPI/Compatibility/CustomRegion.cs
+++ b/InscryptionAPI/Compatibility/CustomRegion.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using DiskCardGame;
+using InscryptionAPI.Regions;
+using UnityEngine;
+using VolumetricFogAndMist;
+
+namespace APIPlugin
+{
+	[Obsolete("Use RegionManager instead", true)]
+	public class CustomRegion
+	{
+		public CustomRegion(string name)
+		{
+			this.name = name;
+            RegionManager.ModifyRegionsList += ModifyRegions;
+		}
+
+        public List<RegionData> ModifyRegions(List<RegionData> regions)
+        {
+            RegionData regionToModify = regions.FirstOrDefault(r => r.name.Equals(this.name));
+            if (regionToModify != null)
+                AdjustRegion(regionToModify);
+
+            return regions;
+        }
+
+		public RegionData AdjustRegion(RegionData region)
+		{
+			TypeMapper<CustomRegion, RegionData>.Convert(this, region);
+			return region;
+		}
+
+		public string name;
+		public int? tier;
+		public List<CardInfo> terrainCards;
+		public List<ConsumableItemData> consumableItems;
+		public List<EncounterBlueprintData> encounters;
+		public List<Opponent.Type> bosses;
+		public List<CardInfo> likelyCards;
+		public List<Tribe> dominantTribes;
+		public PredefinedNodes predefinedNodes;
+		public EncounterBlueprintData bossPrepEncounter;
+		public StoryEventCondition bossPrepCondition;
+		public List<ScarceSceneryEntry> scarceScenery;
+		public List<FillerSceneryEntry> fillerScenery;
+		public PredefinedScenery predefinedScenery;
+		public string ambientLoopId;
+		public bool? silenceCabinAmbience;
+		public Color? boardLightColor;
+		public Color? cardsLightColor;
+		public bool? dustParticlesDisabled;
+		public bool? fogEnabled;
+		public VolumetricFogProfile fogProfile;
+		public float? fogAlpha;
+		public Texture mapAlbedo;
+		public Texture mapEmission;
+		public Color? mapEmissionColor;
+		public List<GameObject> mapParticlesPrefabs;
+	}
+}

--- a/InscryptionAPI/Compatibility/NewEncounter.cs
+++ b/InscryptionAPI/Compatibility/NewEncounter.cs
@@ -1,0 +1,109 @@
+using DiskCardGame;
+using InscryptionAPI;
+using InscryptionAPI.Encounters;
+using InscryptionAPI.Regions;
+using UnityEngine;
+
+namespace APIPlugin
+{
+	[Obsolete("Use EncounterManager instead", true)]
+	public class NewEncounter
+	{
+        private List<RegionData> SyncRegion(List<RegionData> region)
+        {
+            EncounterBlueprintData curClone = EncounterManager.AllEncountersCopy.FirstOrDefault(e => e.name.Equals(this.encounterBlueprintData.name));
+            if (curClone == null)
+            {
+                InscryptionAPIPlugin.Logger.LogDebug($"Could not attach encounter named {this.encounterBlueprintData.name}");
+                return region;
+            }
+
+            if (curClone.regionSpecific) // Does this belong only to a single region?
+            {
+                if (!string.IsNullOrEmpty(this.regionName))
+                {
+                    RegionData target = region.FirstOrDefault(r => r.name.Equals(this.regionName));
+                    if (target != null)
+                    {
+                        if (!bossPrep && !target.encounters.Any(e => e.name.Equals(curClone.name)))
+                        {
+                            InscryptionAPIPlugin.Logger.LogDebug($"Attaching encounter named {this.encounterBlueprintData.name} to region {target.name}");
+                            target.encounters.Add(curClone);
+                        }
+                        
+                        if (bossPrep)
+                            target.bossPrepEncounter = curClone;
+                    }
+                }
+            }
+            else
+            {
+                foreach (RegionData target in region)
+                {
+                    if (!target.encounters.Any(e => e.name.Equals(curClone.name)))
+                    {
+                        InscryptionAPIPlugin.Logger.LogDebug($"Attaching encounter named {this.encounterBlueprintData.name} to region {target.name}");
+                        target.encounters.Add(curClone);
+                    }
+                }
+            }            
+
+            return region;
+        }
+
+		public NewEncounter(string name, EncounterBlueprintData encounterBlueprintData, string regionName, bool regular, bool bossPrep)
+		{
+			this.name = name;
+			this.encounterBlueprintData = encounterBlueprintData;
+            this.encounterBlueprintData.name = name;
+			this.regionName = regionName;
+			this.bossPrep = bossPrep;
+			this.regular = regular;
+
+            EncounterManager.Add(encounterBlueprintData);
+            RegionManager.ModifyRegionsList += SyncRegion;
+            RegionManager.SyncRegionList();
+		}
+
+		public static void Add(string name, string regionName, List<EncounterBlueprintData.TurnModBlueprint> turnMods = null, List<Tribe> dominantTribes = null, List<Ability> redundantAbilities = null, List<CardInfo> unlockedCardPrerequisites = null, bool regionSpecific = true, int minDifficulty = 0, int maxDifficulty = 30, List<CardInfo> randomReplacementCards = null, List<List<EncounterBlueprintData.CardBlueprint>> turns = null, bool regular = true, bool bossPrep = false, int oldPreviewDifficulty = 0)
+		{
+			EncounterBlueprintData encounterBlueprintData = ScriptableObject.CreateInstance<EncounterBlueprintData>();
+			if (turnMods != null)
+			{
+				encounterBlueprintData.turnMods = turnMods;
+			}
+			if (dominantTribes != null)
+			{
+				encounterBlueprintData.dominantTribes = dominantTribes;
+			}
+			if (redundantAbilities != null)
+			{
+				encounterBlueprintData.redundantAbilities = redundantAbilities;
+			}
+			if (unlockedCardPrerequisites != null)
+			{
+				encounterBlueprintData.unlockedCardPrerequisites = unlockedCardPrerequisites;
+			}
+			encounterBlueprintData.regionSpecific = regionSpecific;
+			encounterBlueprintData.minDifficulty = minDifficulty;
+			encounterBlueprintData.maxDifficulty = maxDifficulty;
+			if (randomReplacementCards != null)
+			{
+				encounterBlueprintData.randomReplacementCards = randomReplacementCards;
+			}
+			if (turns != null)
+			{
+				encounterBlueprintData.turns = turns;
+			}
+			encounterBlueprintData.oldPreviewDifficulty = oldPreviewDifficulty;
+			new NewEncounter(name, encounterBlueprintData, regionName, regular, bossPrep);
+		}
+
+		public static List<NewEncounter> encounters = new List<NewEncounter>();
+		public string name;
+		public string regionName;
+		public bool regular;
+		public bool bossPrep;
+		public EncounterBlueprintData encounterBlueprintData;
+	}
+}

--- a/InscryptionAPI/Compatibility/NewRegion.cs
+++ b/InscryptionAPI/Compatibility/NewRegion.cs
@@ -1,0 +1,14 @@
+using DiskCardGame;
+using InscryptionAPI.Regions;
+
+namespace APIPlugin
+{
+    [Obsolete("Use RegionManager instead", true)]
+	public class NewRegion
+	{
+		public NewRegion(RegionData region, int tier)
+		{
+            RegionManager.Add(region, tier);
+		}
+	}
+}

--- a/InscryptionAPI/Encounters/EncounterManager.cs
+++ b/InscryptionAPI/Encounters/EncounterManager.cs
@@ -23,7 +23,7 @@ public static class EncounterManager
         return retval;
     }
 
-    internal static void SyncEncounterList()
+    public static void SyncEncounterList()
     {
         var encounters = BaseGameEncounters.Concat(NewEncounters).Select(x => x.CloneAndReplace()).ToList();
         //var encounters = BaseGameEncounters.Concat(NewEncounters).ToList();

--- a/InscryptionAPI/Encounters/EncounterManager.cs
+++ b/InscryptionAPI/Encounters/EncounterManager.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using DiskCardGame;
 using HarmonyLib;
+using InscryptionAPI.Regions;
 using UnityEngine;
 
 namespace InscryptionAPI.Encounters;
@@ -14,9 +15,17 @@ public static class EncounterManager
 
     public static event Func<List<EncounterBlueprintData>, List<EncounterBlueprintData>> ModifyEncountersList;
 
+    private static EncounterBlueprintData CloneAndReplace(this EncounterBlueprintData data)
+    {
+        EncounterBlueprintData retval = (EncounterBlueprintData)UnityEngine.Object.Internal_CloneSingle(data);
+        retval.name = data.name;
+        RegionManager.ReplaceBlueprintInCore(retval);
+        return retval;
+    }
+
     internal static void SyncEncounterList()
     {
-        var encounters = BaseGameEncounters.Concat(NewEncounters).Select(x => (EncounterBlueprintData)UnityEngine.Object.Internal_CloneSingle(x)).ToList();
+        var encounters = BaseGameEncounters.Concat(NewEncounters).Select(x => x.CloneAndReplace()).ToList();
         //var encounters = BaseGameEncounters.Concat(NewEncounters).ToList();
         AllEncountersCopy = ModifyEncountersList?.Invoke(encounters) ?? encounters;
     }

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -28,7 +28,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="BepInEx.Core" Version="5.4.16" />
-      <PackageReference Include="Inscryption.GameLibs" Version="0.23.0-r.0" />
+      <PackageReference Include="Inscryption.GameLibs" Version="0.30.0-r.0" />
       <PackageReference Include="UnityEngine.Modules" Version="2019.4.24" />
     </ItemGroup>
 

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -72,6 +72,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 
     public void Start()
     {
+        CardManager.ActivateEvents();
         CardManager.ResolveMissingModPrefixes();
         ResyncAll();
     }

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -2,8 +2,11 @@
 
 using BepInEx;
 using BepInEx.Logging;
+using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Card;
+using InscryptionAPI.Encounters;
+using InscryptionAPI.Regions;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Assembly-CSharp")]
@@ -59,10 +62,31 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
         HarmonyInstance.UnpatchSelf();
     }
 
+    internal static void ResyncAll()
+    {
+        CardManager.SyncCardList();
+        AbilityManager.SyncAbilityList();
+        EncounterManager.SyncEncounterList();
+        RegionManager.SyncRegionList();
+    }
+
     public void Start()
     {
         CardManager.ResolveMissingModPrefixes();
-        CardManager.SyncCardList();
-        AbilityManager.SyncAbilityList();
+        ResyncAll();
+    }
+
+    [HarmonyPatch(typeof(AscensionMenuScreens), nameof(AscensionMenuScreens.TransitionToGame))]
+    [HarmonyPrefix]
+    private static void SyncCardsAndAbilitiesWhenTransitioningToAscensionGame()
+    {
+        ResyncAll();
+    }
+
+    [HarmonyPatch(typeof(MenuController), nameof(MenuController.TransitionToGame))]
+    [HarmonyPrefix]
+    private static void SyncCardsAndAbilitiesWhenTransitioningToGame()
+    {
+        ResyncAll();
     }
 }

--- a/InscryptionAPI/Regions/RegionExtensions.cs
+++ b/InscryptionAPI/Regions/RegionExtensions.cs
@@ -132,10 +132,19 @@ public static class RegionExtensions
         region.encounters = region.encounters ?? new();
         foreach (EncounterBlueprintData encounterData in encounters)
         {
-            if (!region.encounters.Contains(encounterData))
+            bool assigned = false;
+            for (int i = 0; i < region.encounters.Count; i++)
             {
-                region.encounters.Add(encounterData);
+                if (region.encounters[i].name.Equals(encounterData))
+                {
+                    region.encounters[i] = encounterData;
+                    assigned = true;
+                    break;
+                }
             }
+
+            if (!assigned)
+                region.encounters.Add(encounterData);
         }
         return region;
     }

--- a/InscryptionAPI/Regions/RegionManager.cs
+++ b/InscryptionAPI/Regions/RegionManager.cs
@@ -37,7 +37,7 @@ public static class RegionManager
         return retval;
     }
 
-    internal static void SyncRegionList()
+    public static void SyncRegionList()
     {
         var regions = BaseGameRegions.Concat(NewRegions.Select(x => x.Region)).Select(x => x.CloneRegion()).ToList();
         AllRegionsCopy = ModifyRegionsList?.Invoke(regions) ?? regions;

--- a/InscryptionAPI/Regions/RegionManager.cs
+++ b/InscryptionAPI/Regions/RegionManager.cs
@@ -52,6 +52,9 @@ public static class RegionManager
 
         RegionData ascensionFinalRegion = AllRegionsCopy.FirstOrDefault(rd => rd.name.Equals(RegionProgression.Instance.ascensionFinalRegion.name));
         RegionProgression.Instance.ascensionFinalRegion = ascensionFinalRegion;
+
+        RegionData specialFinalRegion = AllRegionsCopy.FirstOrDefault(rd => rd.name.Equals(RegionProgression.Instance.ascensionFinalBossRegion.name));
+        RegionProgression.Instance.ascensionFinalBossRegion = specialFinalRegion;
     }
 
     static RegionManager()
@@ -151,7 +154,10 @@ public static class RegionManager
         {
             if (RunState.Run.regionTier == RegionProgression.Instance.regions.Count - 1)
             {
-                __result = RegionProgression.Instance.ascensionFinalRegion;
+                if (AscensionSaveData.Data.ChallengeIsActive(AscensionChallenge.FinalBoss))
+                    __result = RegionProgression.Instance.ascensionFinalBossRegion;
+                else
+                    __result = RegionProgression.Instance.ascensionFinalRegion;
                 return false;
             }
             __result = GetRandomRegionFromTier(RunState.Run.regionOrder[RunState.Run.regionTier]);

--- a/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
@@ -32,7 +32,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="BepInEx.Core" Version="5.4.16" />
-      <PackageReference Include="Inscryption.GameLibs" Version="0.23.0-r.0" />
+      <PackageReference Include="Inscryption.GameLibs" Version="0.30.0-r.0" />
       <PackageReference Include="UnityEngine.Modules" Version="2019.4.24" />
     </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,24 @@ public class Sharp : AbilityBehaviour
 }
 ```
 
+#### Additional functionality
+
+There are two specific common use cases for abilities that are not given to you by the standard AbilityBehaviour class. However, this API comes with an ExtendedAbilityBehaviour class that will allow you to do the following:
+
+**Modify which card slots the card attacks**: To do this, you need to override RespondsToGetOpposingSlots to return true, and then override GetOpposingSlots to return the list of card slots that your ability wants the card to attack. If you want to override the default slot (the one directly across from the card) instead of adding an additional card slot, you need to override RemoveDefaultAttackSlot to return true.
+
+**Add a passive attack or health buff**: To do this, you need to override ProvidesPassiveAttackBuff or ProvidesPassiveHealthBuff to return true, then override GetPassiveAttackBuffs or GetPassiveHealthBuffs to calculate the appropriate buffs. These return an array of integers, which corresponds to the card slots on the battlefield.
+
+For example: Let's assume the card slots look like this:
+
+```
+[A][B][C][D]
+```
+
+If card C wants to provide a +1 attack buff to cards B and D, it needs to return the array \[0, 1, 0, 1\] from GetPassiveAttackBuffs.
+
+Note: you need to be very careful about how complicated the logic is in GetPassiveAttackBuffs and GetPassiveHealthBuffs. These will be called *every frame!!* If you're not careful, you could bog the game down substantially.
+
 ### Special Stat Icons
 
 Think of these like abilities for your stats (like the Ant power or Bell power from the vanilla game). You need to create a StatIconInfo object and build a type that inherits from VariableStatBehaviour in order to implement a special stat. By now, the pattern used by this API should be apparent.
@@ -381,6 +399,8 @@ public class BellProximity : VariableStatBehaviour
     }
 }
 ```
+
+Note: you need to be very careful about how complicated the logic is in GetStatValues. This will be called *every frame!!* If you're not careful, you could bog the game down substantially.
 
 ### Special Triggered Abilities
 


### PR DESCRIPTION
This PR does two things:

1) Adds backwards-compatibility for regions and encounters

2) Fixes defects in the RegionManager and EncounterManager where the connection between regions, encounters, and the global RegionProgression instance could get desynced due the cloning of objects in the managers.