### PR TITLE
Card prefix fixes

### DIFF
--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -13,20 +13,7 @@ public static class CardExtensions
     /// <param name="cards">An enumeration of Inscryption cards</param>
     /// <param name="name">The name to search for (case sensitive).</param>
     /// <returns>The first matching card, or null if no match</returns>
-    public static CardInfo CardByName(this IEnumerable<CardInfo> cards, string name)
-    {
-        CardInfo retVal = null;
-        foreach (var card in cards)
-        {
-            var cardName = card.name;
-
-            if (cardName.Equals(name, StringComparison.OrdinalIgnoreCase))
-                return card;
-            else if (retVal is null && cardName.EndsWith("_" + name))
-                retVal = card;
-        }
-        return retVal;
-    }
+    public static CardInfo CardByName(this IEnumerable<CardInfo> cards, string name) => cards.FirstOrDefault(c => c.name.Equals(name));
 
     private static Sprite GetPortrait(Texture2D portrait, TextureHelper.SpriteType spriteType, FilterMode? filterMode)
     {
@@ -772,5 +759,17 @@ public static class CardExtensions
     {
         bool? isBGC = info.GetExtendedPropertyAsBool("BaseGameCard");
         return isBGC.HasValue && isBGC.Value;
+    }
+
+    internal static CardInfo SetOldApiCard(this CardInfo info, bool isOldApiCard = true)
+    {
+        info.SetExtendedProperty("AddedByOldApi", isOldApiCard);
+        return info;
+    }
+
+    internal static bool IsOldApiCard(this CardInfo info)
+    {
+        bool? isOAPI = info.GetExtendedPropertyAsBool("AddedByOldApi");
+        return isOAPI.HasValue && isOAPI.Value;
     }
 }

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -377,6 +377,9 @@ public static class CardExtensions
                 CardInfo target = cards.CardByName(info.name);
                 CardInfo tailCard = cards.CardByName(tailName);
 
+                if (target != null && tailCard == null && target.IsOldApiCard()) // Maybe this is due to poor naming conventions allowed by the old API.
+                    tailCard = cards.CardByName($"{target.GetModPrefix()}_{tailName}");
+
                 if (target != null && tailCard != null)
                     target.SetTail(tailCard, tailLostPortrait, filterMode, mods);
 
@@ -425,6 +428,9 @@ public static class CardExtensions
             {
                 CardInfo target = cards.CardByName(info.name);
                 CardInfo creatureWithinCard = cards.CardByName(iceCubeName);
+
+                if (target != null && creatureWithinCard == null && target.IsOldApiCard()) // Maybe this is due to poor naming conventions allowed by the old API.
+                    creatureWithinCard = cards.CardByName($"{target.GetModPrefix()}_{iceCubeName}");
 
                 if (target != null && creatureWithinCard != null)
                     target.SetIceCube(creatureWithinCard, mods);
@@ -478,6 +484,9 @@ public static class CardExtensions
             {
                 CardInfo target = cards.CardByName(info.name);
                 CardInfo evolveIntoCard = cards.CardByName(evolveInto);
+
+                if (target != null && evolveIntoCard == null && target.IsOldApiCard()) // Maybe this is due to poor naming conventions allowed by the old API.
+                    evolveIntoCard = cards.CardByName($"{target.GetModPrefix()}_{evolveInto}");
 
                 if (target != null && evolveIntoCard != null)
                     target.SetEvolve(evolveIntoCard, numberOfTurns, mods);

--- a/InscryptionAPI/Compatibility/NewCard.cs
+++ b/InscryptionAPI/Compatibility/NewCard.cs
@@ -60,8 +60,17 @@ namespace APIPlugin
 			Texture2D emissionTex = null, GameObject animatedPortrait = null, List<Texture> decals = null,
 			EvolveIdentifier evolveId = null, IceCubeIdentifier iceCubeId = null, TailIdentifier tailId = null)
 		{
-            CardInfo info = CardManager.New(name, displayedName, baseAttack, baseHealth, description)
-                                       .SetCost(bloodCost, bonesCost, energyCost, gemsCost);
+
+            CardInfo info = ScriptableObject.CreateInstance<CardInfo>();
+            info.SetOldApiCard(true);
+
+            info.name = name;
+            info.displayedName = displayedName;
+            info.baseAttack = baseAttack;
+            info.baseHealth = baseHealth;
+            info.description = description;
+            
+            info.SetCost(bloodCost, bonesCost, energyCost, gemsCost);
 
             info.hideAttackAndHealth = hideAttackAndHealth;
             info.cardComplexity = cardComplexity;
@@ -125,6 +134,8 @@ namespace APIPlugin
 
             if (tailId != null)
                 info.SetTail(tailId.name, tailId.tailLostTex, mods:new List<CardModificationInfo>() { tailId.mods });
+
+            CardManager.Add(info);
 		}
 
         internal static void AssignSpecialAbilities(this CardInfo info, IEnumerable<SpecialAbilityIdentifier> ids)

--- a/README.md
+++ b/README.md
@@ -232,12 +232,12 @@ It's possible that at the time your card is built, the card that you want to evo
 However, note that if you use these extension methods to build these parameters, and the card does not exist yet, the parameters will come back null. You will not see the evolve parameters until you add the evolution to the card list **and** you get a fresh copy of the card from CardLoader (as would happen in game).
 
 ```c#
-CardManager.New("Base", "Base Card", 2, 2).SetEvolve("Evolve Card", 1); // "Evolve Card" hasn't been built yet
-Plugin.Log.LogInfo(CardLoader.GetCardByName("Base").evolveParams == null); // TRUE!
+CardManager.New("Example", "Base", "Base Card", 2, 2).SetEvolve("Evolve Card", 1); // "Evolve Card" hasn't been built yet
+Plugin.Log.LogInfo(CardLoader.GetCardByName("Example_Base").evolveParams == null); // TRUE!
 
-CardInfo myEvolveCard = CardManager.New("Evolve", "Evolve Card", 2, 5);
+CardInfo myEvolveCard = CardManager.New("Example", "Evolve", "Evolve Card", 2, 5);
 
-Plugin.Log.LogInfo(CardLoader.GetCardByName("Base").evolveParams == null); // FALSE!
+Plugin.Log.LogInfo(CardLoader.GetCardByName("Example_Base").evolveParams == null); // FALSE!
 ```
 
 ### Editing existing cards


### PR DESCRIPTION
This PR does two things:

A small thing: it fixes defects in the energy drone manager.

A big thing: It makes the card prefix a required property to CardManager.Add() and .New(); however, it is still optional for mods using the backwards compatibility mode of the API (to prevent old mods from immediately breaking).