### PR TITLE
Update cost renders to count card mod cost changes

### DIFF
--- a/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
@@ -51,14 +51,14 @@ public static class Part1CardCostRender
 
 	internal static string GemCost(CardInfo info)
 	{
-		return (info.gemsCost.Contains(GemType.Orange) ? "o": string.Empty) + 
-			   (info.gemsCost.Contains(GemType.Blue) ? "b": string.Empty) + 
-			   (info.gemsCost.Contains(GemType.Green) ? "g": string.Empty);
+		return (info.GemsCost.Contains(GemType.Orange) ? "o": string.Empty) + 
+			   (info.GemsCost.Contains(GemType.Blue) ? "b": string.Empty) + 
+			   (info.GemsCost.Contains(GemType.Green) ? "g": string.Empty);
 	}
 
 	public static Sprite Part1SpriteFinal(CardInfo card)
 	{
-		string costKey = $"b{card.cost}_o{card.bonesCost}_g{card.energyCost}_e{GemCost(card)}";
+		string costKey = $"b{card.BloodCost}_o{card.BonesCost}_g{card.EnergyCost}_e{GemCost(card)}";
 
 		if (AssembledTextures.ContainsKey(costKey))
 		{
@@ -91,14 +91,14 @@ public static class Part1CardCostRender
 			list.Add(CombineMoxTextures(gemCost));
 		}
 
-		if (card.energyCost > 0)
-			list.Add(GetTextureByName($"energy_cost_{card.energyCost}"));
+		if (card.EnergyCost > 0)
+			list.Add(GetTextureByName($"energy_cost_{card.EnergyCost}"));
 
-		if (card.bonesCost > 0)
-			list.Add(GetTextureByName($"bone_cost_{card.bonesCost}"));
+		if (card.BonesCost > 0)
+			list.Add(GetTextureByName($"bone_cost_{card.BonesCost}"));
 
-		if (card.cost > 0)
-			list.Add(GetTextureByName($"blood_cost_{card.cost}"));
+		if (card.BloodCost > 0)
+			list.Add(GetTextureByName($"blood_cost_{card.BloodCost}"));
 
 		// Call the event and allow others to modify the list of textures
 		UpdateCardCost?.Invoke(card, list);

--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -42,7 +42,7 @@ public static class Part2CardCostRender
 
     public static Sprite Part2SpriteFinal(CardInfo card, bool left=true)
     {
-        string costKey = $"b{card.cost}_o{card.bonesCost}_g{card.energyCost}_e{Part1CardCostRender.GemCost(card)}";
+        string costKey = $"b{card.BloodCost}_o{card.BonesCost}_g{card.EnergyCost}_e{Part1CardCostRender.GemCost(card)}";
 
         if (AssembledTextures.ContainsKey(costKey))
 		{
@@ -55,14 +55,14 @@ public static class Part2CardCostRender
         //A list to hold the textures (important later, to combine them all)
         List<Texture2D> masterList = new List<Texture2D>();
 
-        if (card.cost > 0)
-            masterList.Add(GetFinalTexture(card.cost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly), left)); 
+        if (card.BloodCost > 0)
+            masterList.Add(GetFinalTexture(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly), left)); 
 
-        if (card.bonesCost > 0)
-            masterList.Add(GetFinalTexture(card.bonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly), left));
+        if (card.BonesCost > 0)
+            masterList.Add(GetFinalTexture(card.BonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly), left));
 
-        if (card.energyCost > 0)
-            masterList.Add(GetFinalTexture(card.energyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly), left));
+        if (card.EnergyCost > 0)
+            masterList.Add(GetFinalTexture(card.EnergyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly), left));
         
         if (card.gemsCost.Count > 0)
         {


### PR DESCRIPTION
This is a very simple bug fix that was reported by teamdoodz in Discord.

The cost render patch was using the private fields instead of the public properties for cost, which meant that they weren't accounting for changes due to the card having CardModificationInfos set on it. This PR switches from the fields to the properties.